### PR TITLE
ajout de la class .flex-container

### DIFF
--- a/sass/_02-layout.scss
+++ b/sass/_02-layout.scss
@@ -103,7 +103,8 @@ body > script {
 http://www.alsacreations.com/tuto/lire/1493-css3-flexbox-layout-module.html
 */
 
-[class*="#{$kna-namespace}flex-container"] {
+[class*="#{$kna-namespace}flex-container"],
+.#{$kna-namespace}flex-container{
   display : flex;
   flex-wrap: wrap;
 }


### PR DESCRIPTION
Pour pouvoir utiliser .flex-container en Sass directement. 