### PR TITLE
#232 No styling on a:hover if there's no effect

### DIFF
--- a/sass/_config/_variables.scss
+++ b/sass/_config/_variables.scss
@@ -26,8 +26,9 @@ $color5    : #6FA939 !default;
 $base-color: $color1;
 $link-color: $color3;
 $base-background : $color2;
-$link-hover-color: $color4; // Make it equal to either $link-color or false if you don't want
-                            // any effect on links when focused/hovered
+// If you don't want any effect on focused/hovered links,
+// comment variable below or make it equal to either $link-color or false or null
+$link-hover-color: $color4;
 $brand-primary: $color5;
 
 

--- a/sass/_config/_variables.scss
+++ b/sass/_config/_variables.scss
@@ -26,7 +26,7 @@ $color5    : #6FA939 !default;
 $base-color: $color1;
 $link-color: $color3;
 $base-background : $color2;
-$link-hover-color: $color4; // Make it equal to $link-color if you don't want
+$link-hover-color: $color4; // Make it equal to either $link-color or false if you don't want
                             // any effect on links when focused/hovered
 $brand-primary: $color5;
 

--- a/sass/_config/_variables.scss
+++ b/sass/_config/_variables.scss
@@ -26,7 +26,8 @@ $color5    : #6FA939 !default;
 $base-color: $color1;
 $link-color: $color3;
 $base-background : $color2;
-$link-hover-color: $color4;
+$link-hover-color: $color4; // Make it equal to $link-color if you don't want
+                            // any effect on links when focused/hovered
 $brand-primary: $color5;
 
 

--- a/sass/library/_base.scss
+++ b/sass/library/_base.scss
@@ -32,11 +32,12 @@ a {
 
   // No styling on focus/hover if there's no effect. Avoids to then have to
   // override it countless times. See Issue #232
-  @if ($link-hover-color != $link-color and $link-hover-color != false) {
+  @if variable_exists(link-hover-color) and
+      ( null == index( ($link-color, null, false), $link-hover-color) ) {
     &:focus,
     &:hover,
     &:active {
-        color: $link-hover-color;
+      color: $link-hover-color;
     }
   }
 }

--- a/sass/library/_base.scss
+++ b/sass/library/_base.scss
@@ -30,10 +30,14 @@ body {
 a {
   color: $link-color;
 
-  &:focus,
-  &:hover,
-  &:active {
-    color: $link-hover-color;
+  // No styling on focus/hover if there's no effect. Avoids to then have to
+  // override it countless times. See Issue #232
+  @if $link-hover-color != $link-color {
+    &:focus,
+    &:hover,
+    &:active {
+        color: $link-hover-color;
+    }
   }
 }
 

--- a/sass/library/_base.scss
+++ b/sass/library/_base.scss
@@ -32,7 +32,7 @@ a {
 
   // No styling on focus/hover if there's no effect. Avoids to then have to
   // override it countless times. See Issue #232
-  @if $link-hover-color != $link-color {
+  @if ($link-hover-color != $link-color and $link-hover-color != false) {
     &:focus,
     &:hover,
     &:active {


### PR DESCRIPTION
Cf. #232

Testé en déclarant `$link-hover-color: $link-color;` dans `_variables.scss` : cela fonctionne puisque la règle dans le if ne fait plus partie des CSS compilées. Et là il n'y a aucun changement dans les CSS compilées.

Par contre si on ne déclare plus la variable `$link-hover-color`, la compilation plante avec le message `Error: Undefined variable: "$link-hover-color"`