### PR TITLE
Correction d'une probable erreur de copier/coller

### DIFF
--- a/sass/library/_base.scss
+++ b/sass/library/_base.scss
@@ -142,7 +142,7 @@ h6, .#{$kna-namespace}h6-like {
   font-size: $h6-size;
   @if variable_exists(h6-size-l) and $h6-size-l != $h6-size {
     @include respond-to("tiny-up") {
-      font-size: $h1-size-l;
+      font-size: $h6-size-l;
     }
   }
 }


### PR DESCRIPTION
.h6-like a pour taille $h6-size, quand les grandes tailles sont définies, c'est vraisemblablement $h6-size-l (et non $h1-size-l)