### PR TITLE
Fixing some deprecation warning while using KNACSS in a Laravel project

### DIFF
--- a/sass/_config/_variables.scss
+++ b/sass/_config/_variables.scss
@@ -82,6 +82,9 @@ $hyphens: false !default;
 // Number of grid-columns
 $cols: 12 !default;
 
+// Gutter
+$gutter: null;
+
 // Grid gutters (for .has-gutter-* classes)
 $grid-gutters: (
   '': 1rem,


### PR DESCRIPTION
```
DEPRECATION WARNING: As of Dart Sass 2.0.0, !global assignments won't be able to
declare new variables. Consider adding `$gutter: null` at the top level.

   ╷
24 │       $gutter: $grid-gutters !global;
   │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/knacss/sass/_library/grillade-grid.scss 24:7  @import
    node_modules/knacss/sass/knacss.scss 51:9                  @import
    stdin 6:9                                                  root stylesheet
```